### PR TITLE
fix npm deps (minimatch sec risk)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test"
   ],
   "dependencies": {
-    "archiver": "^0.14.4",
+    "archiver": "^1.0.0",
     "commander": "^2.8.1",
     "fstream": "^1.0.7",
     "jsforce": "^1.5.0",
@@ -44,9 +44,9 @@
     "xml2js": "^0.4.10"
   },
   "devDependencies": {
-    "espower-loader": "^0.10.0",
-    "intelli-espower-loader": "^0.6.0",
+    "espower-loader": "^1.0.0",
+    "intelli-espower-loader": "^1.0.1",
     "mocha": "^2.2.5",
-    "power-assert": "^0.11.0"
+    "power-assert": "^1.4.1"
   }
 }

--- a/test/fixture/pkg1/package.xml
+++ b/test/fixture/pkg1/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>JSforceRetrievePackage1</fullName>
     <types>
         <members>*</members>
         <name>ApexClass</name>

--- a/test/fixture/pkg2/package.xml
+++ b/test/fixture/pkg2/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>JSforceRetrievePackage2</fullName>
     <types>
         <members>*</members>
         <name>ApexClass</name>


### PR DESCRIPTION
@stomita 

updated npm packages and ran test

Noted: had to add FullName to create package by Name

This PR is to fix outdated npm modules that are causing failures see below.

Please let me know if this works. 

Thank You

```
> generator-force@1.0.8 prepublish /home/travis/build/CodeScience/generator-force
> gulp prepublish
[12:02:23] Using gulpfile ~/build/CodeScience/generator-force/gulpfile.js
[12:02:23] Starting 'nsp'...
[12:02:28] 'nsp' errored after 5.58 s
[12:02:28] Error in plugin 'gulp-nsp'
Message:
    (+) 1 vulnerabilities found
┌───────────────┬───────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                  │
├───────────────┼───────────────────────────────────────────────────────┤
│ Name          │ minimatch                                             │
├───────────────┼───────────────────────────────────────────────────────┤
│ Installed     │ 2.0.10                                                │
├───────────────┼───────────────────────────────────────────────────────┤
│ Vulnerable    │ <=3.0.1                                               │
├───────────────┼──���────────────────────────────────────────────────────┤
│ Patched       │ >=3.0.2                                               │
├───────────────┼───────────────────────────────────────────────────────┤
│ Path          │ generator-force@1.0.8 > jsforce-metadata-tools@1.2.2… │
├───────────────┼───────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/118                │
└───────────────┴───────────────────────────────────────────────────────┘
```
