### PR TITLE
Replace unzip utility with decompress (fixes #6)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -160,7 +160,7 @@ function retrieve() {
   .then(function(res) {
     console.log('');
     tools.reportRetrieveResult(res, console, program.verbose);
-    if (!res.success) {
+    if (res.success !== 'true') {
       console.log('');
       console.log('No output files generated.');
       return false;

--- a/lib/retrieve.js
+++ b/lib/retrieve.js
@@ -1,12 +1,12 @@
 'use strict';
 
+var decompress = require('decompress');
 var fs = require('fs');
 var fstream = require('fstream');
 var path = require('path');
 var stream = require('readable-stream');
 var jsforce = require('jsforce');
 var archiver = require('archiver');
-var unzip = require('unzip');
 var xml2js = require('xml2js');
 var Promise = jsforce.Promise;
 var connect = require('./connect');
@@ -138,40 +138,20 @@ function reportRetreiveFileProperties(fileProperties, logger) {
  */
 function extractZipContents(zipFileContent, dirMapping, logger, verbose) {
   logger.log('');
-  return new Promise(function(resolve, reject) {
-    var waits = [];
-    var zipStream = new stream.PassThrough();
-    zipStream.end(new Buffer(zipFileContent, 'base64'));
-    zipStream
-      .pipe(unzip.Parse())
-      .on('entry', function(entry) {
-        var filePaths = entry.path.split('/');
-        var packageName = filePaths[0];
-        var directory = dirMapping[packageName] || dirMapping['*'];
-        if (directory) {
-          var restPath = filePaths.slice(1).join('/');
-          var realPath = path.join(directory, restPath);
-          waits.push(new Promise(function(rsv, rej) {
-            logger.log('Extracting: ', realPath);
-            entry.pipe(
-                fstream.Writer({
-                  type: entry.type,
-                  path: realPath
-                })
-              )
-              .on('finish', rsv)
-              .on('error', rej);
-          }));
-        } else {
-          entry.autodrain();
-        }
-      })
-      .on('finish', function() {
-        setTimeout(function() {
-          Promise.all(waits).then(resolve, reject);
-        }, 1000);
-      })
-      .on('error', reject);
+  var zipBuffer = Buffer.from(zipFileContent, 'base64');
+  // returns a promise of file objects, see https://github.com/kevva/decompress#decompressinput-output-options
+  return decompress(zipBuffer, '.', {
+    map: function (file) {
+      var filePaths = file.path.split('/');
+      var packageName = filePaths[0];
+      var directory = dirMapping[packageName] || dirMapping['*'];
+      if (directory) {
+        filePaths[0] = directory;
+      }
+      file.path = filePaths.join('/');
+      logger.log('Extracting: ', file.path);
+      return file;
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "test"
   ],
   "dependencies": {
-    "archiver": "^1.2.0",
-    "commander": "^2.9.0",
-    "fstream": "^1.0.10",
-    "jsforce": "^1.7.1",
-    "readable-stream": "^2.1.5",
-    "unzip": "^0.1.11",
+    "archiver": "^0.14.4",
+    "commander": "^2.8.1",
+    "decompress": "^4.0.0",
+    "fstream": "^1.0.7",
+    "jsforce": "^1.5.0",
+    "readable-stream": "^2.0.2",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "test"
   ],
   "dependencies": {
-    "archiver": "^0.14.4",
-    "commander": "^2.8.1",
+    "archiver": "^1.2.4",
+    "commander": "^2.9.0",
     "decompress": "^4.0.0",
-    "fstream": "^1.0.7",
-    "jsforce": "^1.5.0",
-    "readable-stream": "^2.0.2",
+    "fstream": "^1.0.10",
+    "jsforce": "^1.7.1",
+    "readable-stream": "^2.1.5",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes bug where large metadata zip files crash node by using a more robust unzip utility.